### PR TITLE
Split site's English title into two strings: string in head>title and in 'body letterhead div'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,8 +6,9 @@
 # 'jekyll serve'. If you change this file, please restart the server process.
 
 # Site settings
+title: 2016 Asian Humanism Conference
 title-zh: 2016 亞洲人文主義大會
-title: <div>2016 Asian</div> <div>Humanism</div> <div>Conference</div>
+title-en: <div>2016 Asian</div> <div>Humanism</div> <div>Conference</div>
 email: asianhumanismcon@gmail.com
 description: > # this means to ignore newlines until "baseurl:"
   This site is open to suggestions, so contact us or if you can use github click on the pencil icon to get to the code, make your changes and when you're done click on "Propose file change".

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -29,7 +29,7 @@
       </a>
       <a class="letterhead-title" href="{{ site.baseurl }}{{ this-lang-path-to-index }}">
         {% if page.language == "en" %}
-        {{ site.title }}
+        {{ site.title-en }}
         {% elsif page.language == "zh" %}
         {{ site.title-zh }}
         {% endif %}


### PR DESCRIPTION
This fixed the head>title displaying markdown meant for formatting in letterhead